### PR TITLE
Link .NET Foundation Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,6 @@
-# Microsoft Open Source Code of Conduct
+# Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
 
-Resources:
-
-- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
-- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -101,7 +101,3 @@ The following scenarios have been validated on windows, mac os and ubuntu.
 # Examples
 
 Check [AzCopy.Test](https://github.com/LittleLittleCloud/AzCopy.Net/blob/41856b39ff710cf0f9844d00b73c1ab9bfbb919b/src/AzCopy.Test/AZCopyClientTests.Test.cs#L15) for more examples.
-
-# Contributing
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
This addresses the pending policy violation.

This project currently links the Microsoft Code of Conduct, but it should link the .NET Foundation Code of Conduct. For more details, see [PR15](https://github.com/dotnet/org-policy/blob/main/doc/PR15.md).