### PR TITLE
make CLIArgumentName class public

### DIFF
--- a/ci.yaml
+++ b/ci.yaml
@@ -89,7 +89,6 @@ jobs:
                     /p:Test=False
                     /p:Pack=True
                     /p:Sign=True
-                    /p:DotNetFinalVersionKind=release
                     /p:Publish=True
                     /p:DotNetPublishUsingPipelines=True
                     $(BuildArgs)

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>10.16.2</VersionPrefix>
+    <VersionPrefix>10.16.2.1</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,6 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>10.16.2.1</VersionPrefix>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <VersionPrefix>10.16.2</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/AzCopy.Contract/Commands/CLIArgumentName.cs
+++ b/src/AzCopy.Contract/Commands/CLIArgumentName.cs
@@ -1,6 +1,6 @@
 ﻿namespace AzCopy.Contract
 {
-    internal class CLIArgumentName : System.Attribute
+    public class CLIArgumentName : System.Attribute
     {
         public CLIArgumentName(string name, bool useQuotes = false)
         {


### PR DESCRIPTION
This allows the user to add preview options, which is not recorded in the official document, into azcopy command classes.